### PR TITLE
Ellucian Login First Iteration

### DIFF
--- a/Command/CreateEllucianApiCommand.php
+++ b/Command/CreateEllucianApiCommand.php
@@ -1,0 +1,60 @@
+<?php
+namespace BridgewaterCollege\Bundle\CustomLoginBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+// Additional Includes:
+use BridgewaterCollege\Bundle\CustomLoginBundle\Utils\EllucianColleagueApiHandler;
+
+class CreateEllucianApiCommand extends Command
+{
+    protected $ellucianColleagueApiHandler;
+
+    public function __construct(EllucianColleagueApiHandler $ellucianColleagueApiHandler)
+    {
+        $this->ellucianColleagueApiHandler = $ellucianColleagueApiHandler;
+        // you *must* call the parent constructor
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        // to run manually: php bin/console custom-login:create-ellucian-colleague-api
+        $this
+            ->setName('custom-login:create-ellucian-colleague-api');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('This will overwrite the existing colleague api connection, do you wish to proceed (y/n): ', false);
+        if (!$helper->ask($input, $output, $question)) {
+            $output->writeln("System: Aborting...\r\n");
+            return;
+        }
+
+        $question = new Question('Please enter the colleague proxy account\'s username: ');
+        while(!$username = $helper->ask($input, $output, $question)) {
+            $output->writeln('Warning! username cannot be empty');
+        }
+
+        $question = new Question('Please enter the colleague proxy account\'s password: ');
+        $question->setHidden(true);
+        while(!$password = $helper->ask($input, $output, $question)) {
+            $output->writeln('Warning! password cannot be empty');
+        }
+
+        $question = new Question('Please enter your colleague api\'s base url: ');
+        while(!$url = $helper->ask($input, $output, $question)) {
+            $output->writeln('Warning! url cannot be empty');
+        }
+
+        // once all three prompts are completed, proceed to inserting the new information into the database:
+        $this->ellucianColleagueApiHandler->createEllucianApiAccount($username, $password, $url);
+    }
+}

--- a/Command/LoginToEllucianApiCommand.php
+++ b/Command/LoginToEllucianApiCommand.php
@@ -1,0 +1,41 @@
+<?php
+namespace BridgewaterCollege\Bundle\CustomLoginBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+// Additional Includes:
+use BridgewaterCollege\Bundle\CustomLoginBundle\Utils\EllucianColleagueApiHandler;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class LoginToEllucianApiCommand extends Command
+{
+    protected $ellucianColleagueApiHandler;
+    protected $session;
+
+    public function __construct(EllucianColleagueApiHandler $ellucianColleagueApiHandler, SessionInterface $session)
+    {
+        $this->ellucianColleagueApiHandler = $ellucianColleagueApiHandler;
+        $this->session = $session;
+        // you *must* call the parent constructor
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        // to run manually: php bin/console custom-login:login-to-ellucian-colleague-api
+        $this
+            ->setName('custom-login:login-to-ellucian-colleague-api');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->ellucianColleagueApiHandler->loginToEllucianColleagueApi()) {
+            $output->writeln('Colleague API Authenticated Successfully');
+        }
+    }
+}

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -2,35 +2,35 @@
 // src/Controller/SecurityController.php
 namespace BridgewaterCollege\Bundle\CustomLoginBundle\Controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Container\ContainerInterface;
 use SimpleSAML\Auth\Simple;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 // Custom Includes:
-use BridgewaterCollege\Bundle\CustomLoginBundle\ProcessHandlers\LoginHandler;
+use BridgewaterCollege\Bundle\CustomLoginBundle\Utils\LoginHandler;
 
 class SecurityController extends AbstractController
 {
     private $localRedirectUrl;
 
-    public function login(Request $request, SessionInterface $session){
+    public function login(Request $request, SessionInterface $session, LoginHandler $loginHandler){
         $session->set('original_user_requested_route', $session->get('last_route')['name']);
 
         /** Default Login Url: grabs the "default" login path set in the applications database and kicks off the process */
-        $LoginHandler = $this->container->get('bridgewater_college_custom_login.process_handler.login_handler');
-        $defaultLoginPath = $LoginHandler->getDefaultLoginPath();
+        $defaultLoginPath = $loginHandler->getDefaultLoginPath();
         $redirectUrl = "".$request->getBaseUrl()."/".$defaultLoginPath;
 
         return $this->redirect($redirectUrl);
     }
 
-    public function loginLocal(AuthenticationUtils $authenticationUtils) {
-        $LoginHandler = $this->container->get('bridgewater_college_custom_login.process_handler.login_handler');
-        if (!$LoginHandler->getLoginPathEnabled(1))
+    public function loginLocal(AuthenticationUtils $authenticationUtils, LoginHandler $loginHandler) {
+        if (!$loginHandler->getLoginPathEnabled(1))
             return $this->redirectToRoute('custom_login_landing');
 
         // System: ensure they aren't already authenticated this session
@@ -46,9 +46,8 @@ class SecurityController extends AbstractController
         ]);
     }
 
-    public function loginSaml(Request $request, Simple $as) {
-        $LoginHandler = $this->container->get('bridgewater_college_custom_login.process_handler.login_handler');
-        if (!$LoginHandler->getLoginPathEnabled(2))
+    public function loginSaml(Request $request, Simple $as, LoginHandler $loginHandler) {
+        if (!$loginHandler->getLoginPathEnabled(2))
             return $this->redirectToRoute('custom_login_landing');
 
         // System: ensure they aren't already authenticated this session
@@ -60,9 +59,8 @@ class SecurityController extends AbstractController
         return $this->redirectToRoute('custom_login_landing_saml_check');
     }
 
-    public function loginSamlCheck(Request $request, Simple $as) {
-        $LoginHandler = $this->container->get('bridgewater_college_custom_login.process_handler.login_handler');
-        if (!$LoginHandler->getLoginPathEnabled(2))
+    public function loginSamlCheck(Request $request, Simple $as, LoginHandler $loginHandler) {
+        if (!$loginHandler->getLoginPathEnabled(2))
             return $this->redirectToRoute('custom_login_landing');
 
         /** SAML Authenticator takes over here */

--- a/Entity/EllucianColleagueApi.php
+++ b/Entity/EllucianColleagueApi.php
@@ -1,0 +1,55 @@
+<?php
+namespace BridgewaterCollege\Bundle\CustomLoginBundle\Entity;
+
+use Symfony\Component\Validator\Constraints as Assert;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="ellucian_colleague_api")
+ */
+class EllucianColleagueApi
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(type="string", length=191)
+     */
+    public $username;
+
+    /**
+     * @ORM\Column(type="string", length=191)
+     */
+    protected $password;
+
+    /**
+     * @ORM\Column(type="text")
+     */
+    protected $iv;
+
+    /**
+     * @ORM\Column(type="text")
+     */
+    public $colleagueWebApiUrl;
+
+    public function setPassword($encryptedPass) {
+        $this->password = $encryptedPass;
+    }
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    public function setIv($iv) {
+        $this->iv = $iv;
+    }
+    public function getIv() {
+        return $this->iv;
+    }
+}

--- a/Entity/LoginEndpoint.php
+++ b/Entity/LoginEndpoint.php
@@ -3,7 +3,6 @@ namespace BridgewaterCollege\Bundle\CustomLoginBundle\Entity;
 
 use Symfony\Component\Validator\Constraints as Assert;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**

--- a/Entity/User.php
+++ b/Entity/User.php
@@ -176,6 +176,16 @@ class User implements UserInterface, \Serializable
         return $this->username;
     }
 
+    public function getUsernameNoDomain() {
+        $username = $this->username;
+        if (strpos($this->username, '@') !== false) {
+            $username = explode('@', $username);
+            $username = $username[0];
+        }
+
+        return $username;
+    }
+
     /**
      * @param string $username
      *

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,11 +8,14 @@
         <service id="bridgewater_college_custom_login.controller.security_controller" class="BridgewaterCollege\Bundle\CustomLoginBundle\Controller\SecurityController">
             <tag name="controller.service_arguments"/>
         </service>
-        <service id="bridgewater_college_custom_login.process_handler.login_handler" class="BridgewaterCollege\Bundle\CustomLoginBundle\ProcessHandlers\LoginHandler" autowire="true" public="true" />
+        <service id="BridgewaterCollege\Bundle\CustomLoginBundle\Utils\LoginHandler" autowire="true" public="true" />
         <service id="bridgewater_college_custom_login.login_authenticator" class="BridgewaterCollege\Bundle\CustomLoginBundle\Security\LoginAuthenticator" autowire="true" public="true" />
         <service id="bridgewater_college_custom_login.login_form_authenticator" class="BridgewaterCollege\Bundle\CustomLoginBundle\Security\LoginFormAuthenticator" autowire="true" public="true" />
         <service id="bridgewater_college_custom_login.login_saml_authenticator" class="BridgewaterCollege\Bundle\CustomLoginBundle\Security\LoginSamlAuthenticator" autowire="true" public="true" />
         <service id="BridgewaterCollege\Bundle\CustomLoginBundle\Security\User\UserCreator" autowire="true" public="true"/>
+
+        <service id="BridgewaterCollege\Bundle\CustomLoginBundle\Utils\SecureEncryptor" autowire="true" public="true"/>
+        <service id="BridgewaterCollege\Bundle\CustomLoginBundle\Utils\EllucianColleagueApiHandler" autowire="true"/>
 
         <!-- SimpleSAML Related Services -->
         <service id="SimpleSAML\Auth\Simple" autowire="true" public="true">
@@ -29,6 +32,12 @@
             <tag name="console.command" />
         </service>
         <service id="BridgewaterCollege\Bundle\CustomLoginBundle\Command\UpdateSimpleSamlConfig" autowire="true">
+            <tag name="console.command" />
+        </service>
+        <service id="BridgewaterCollege\Bundle\CustomLoginBundle\Command\CreateEllucianApiCommand" autowire="true">
+            <tag name="console.command" />
+        </service>
+        <service id="BridgewaterCollege\Bundle\CustomLoginBundle\Command\LoginToEllucianApiCommand" autowire="true">
             <tag name="console.command" />
         </service>
     </services>

--- a/Security/LoginFormAuthenticator.php
+++ b/Security/LoginFormAuthenticator.php
@@ -29,7 +29,6 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
     private $router;
     private $csrfTokenManager;
     private $passwordEncoder;
-    private $simplesamlAuthObject;
 
     public function __construct(EntityManagerInterface $entityManager, RouterInterface $router, CsrfTokenManagerInterface $csrfTokenManager, UserPasswordEncoderInterface $passwordEncoder)
     {

--- a/Utils/EllucianColleagueApiHandler.php
+++ b/Utils/EllucianColleagueApiHandler.php
@@ -1,0 +1,74 @@
+<?php
+namespace BridgewaterCollege\Bundle\CustomLoginBundle\Utils;
+
+use BridgewaterCollege\Bundle\CustomLoginBundle\Entity\EllucianColleagueApi;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class EllucianColleagueApiHandler extends ProcessHandler {
+
+    public function createEllucianApiAccount($username, $userPass, $accountUrl) {
+        if (!$ellucianColleagueApi = $this->em->getRepository(EllucianColleagueApi::class)->find(1))
+            $ellucianColleagueApi = new EllucianColleagueApi();
+        $ellucianColleagueApi->username = $username;
+
+        $ellucianColleagueApi->setIv(base64_encode(openssl_random_pseudo_bytes(16, $strong)));
+        $ellucianColleagueApi->setPassword($this->encryptor->encrypt($userPass, base64_decode($ellucianColleagueApi->getIv()), 16));
+        $ellucianColleagueApi->colleagueWebApiUrl = $accountUrl;
+
+        $this->em->persist($ellucianColleagueApi);
+        $this->em->flush();
+    }
+
+    private function getEllucianPass($encryptedPass, $iv) {
+        return $this->encryptor->decrypt($encryptedPass, base64_decode($iv));
+    }
+
+    public function loginToEllucianColleagueApi() {
+        $ellucianConfig = $this->getEllucianColleagueApiConfig();
+        $data = array('UserId' => $ellucianConfig->username, 'Password' => $this->getEllucianPass($ellucianConfig->getPassword(), $ellucianConfig->getIv()));
+        $body = \Unirest\Request\Body::form($data);
+
+        $headers = array('Accept' => 'application/vnd.ellucian.v1+json', 'Cache-Control' => 'no-cache');
+        $response = \Unirest\Request::post('https://arrow.bridgewater.edu:8320/colleagueapi/session/login', $headers, $body);
+
+        if (isset($response->headers[0]) && $response->headers[0] == 'HTTP/1.1 401 Unauthorized') {
+            throw new HttpException(500, $response->body);
+        }
+
+        $this->session->set('ColleagueApiSessionToken', $response->body);
+        return true;
+    }
+
+    public function logoutEllucianColleagueApi() {
+        $ellucianConfig = $this->getEllucianColleagueApiConfig();
+        $headers = array('Accept' => 'application/vnd.ellucian.v1+json', 'Cache-Control' => 'no-cache', 'X-CustomCredentials' => $this->session->get('ColleagueApiSessionToken'));
+        \Unirest\Request::post('https://arrow.bridgewater.edu:8320/colleagueapi/session/logout', $headers, null);
+
+        $this->session->remove('ColleagueApiSessionToken');
+    }
+
+    public function proxyLoginToEllucianColleagueApi() {
+        if ($this->security->getUser() == null)
+            throw new HttpException(500, "Error, proxy authentication not allowed.");
+
+        $ellucianConfig = $this->getEllucianColleagueApiConfig();
+        $data = array('ProxyId' => $ellucianConfig->username, 'ProxyPassword' => $this->getEllucianPass($ellucianConfig->getPassword(), $ellucianConfig->getIv()), 'UserId' => $this->security->getUser()->getUsernameNoDomain());
+        $body = \Unirest\Request\Body::form($data);
+
+        $headers = array('Accept' => 'application/vnd.ellucian.v1+json', 'Cache-Control' => 'no-cache');
+        $response = \Unirest\Request::post('https://arrow.bridgewater.edu:8320/colleagueapi/session/proxy-login', $headers, $body);
+
+        if (isset($response->headers[0]) && $response->headers[0] == 'HTTP/1.1 401 Unauthorized') {
+            throw new HttpException(500, $response->body);
+        }
+
+        $this->session->set('ColleagueApiSessionToken', $response->body);
+    }
+
+    private function getEllucianColleagueApiConfig() {
+        if (!$ellucianColleagueApi = $this->em->getRepository(EllucianColleagueApi::class)->find(1))
+            throw new HttpException(500, "Error no ellucain api configured in system, please run custom-login:create-ellucian-colleague-api to continue...");
+
+        return $ellucianColleagueApi;
+    }
+}

--- a/Utils/LoginHandler.php
+++ b/Utils/LoginHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace BridgewaterCollege\Bundle\CustomLoginBundle\ProcessHandlers;
+namespace BridgewaterCollege\Bundle\CustomLoginBundle\Utils;
 
 use BridgewaterCollege\Bundle\CustomLoginBundle\Entity\LoginEndpoint;
 

--- a/Utils/ProcessHandler.php
+++ b/Utils/ProcessHandler.php
@@ -1,10 +1,12 @@
 <?php
-namespace BridgewaterCollege\Bundle\CustomLoginBundle\ProcessHandlers;
+namespace BridgewaterCollege\Bundle\CustomLoginBundle\Utils;
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Security\Core\Security;
 
 /**
  * Class Type: Process Handler
@@ -17,16 +19,22 @@ class ProcessHandler
 {
     protected $validator_service;
     protected $em;
+    protected $session;
     protected $logger;
+    protected $encryptor;
+    protected $security;
 
     public $errorsArray = array(); // error's array set on validateEntity
     public $pageCanSubmit = false; // determines if the current screen/page can submit (flag)
 
-    public function __construct(ValidatorInterface $validator_service, EntityManagerInterface $em, LoggerInterface $logger)
+    public function __construct(ValidatorInterface $validator_service, EntityManagerInterface $em, SessionInterface $session, LoggerInterface $logger, SecureEncryptor $encryptor, Security $security)
     {
         $this->validator_service = $validator_service;
         $this->em = $em;
+        $this->session = $session;
         $this->logger = $logger;
+        $this->encryptor = $encryptor;
+        $this->security = $security;
     }
 
     public function validateDateIsFuture($dateSelected) {

--- a/Utils/SecureEncryptor.php
+++ b/Utils/SecureEncryptor.php
@@ -1,0 +1,42 @@
+<?php
+namespace BridgewaterCollege\Bundle\CustomLoginBundle\Utils;
+
+class SecureEncryptor {
+
+    public function __construct() {}
+
+    function pkcs7_pad($data, $size)
+    {
+        $length = $size - strlen($data) % $size;
+        return $data . str_repeat(chr($length), $length);
+    }
+
+    function pkcs7_unpad($data)
+    {
+        return substr($data, 0, -ord($data[strlen($data) - 1]));
+    }
+
+    public function encrypt($stringToEncrypt, $iv, $ivSize) {
+        $encryptedString = openssl_encrypt(
+            $this->pkcs7_pad($stringToEncrypt, $ivSize), // padded data
+            'AES-256-CBC',        // cipher and mode
+            $_SERVER['APP_SECRET'],      // secret key
+            0,                    // options (not used)
+            $iv                   // initialisation vector
+        );
+
+        return $encryptedString;
+    }
+
+    public function decrypt($stringToDecrypt, $iv) {
+        $decryptedString = $this->pkcs7_unpad(openssl_decrypt(
+            $stringToDecrypt,
+            'AES-256-CBC',
+            $_SERVER['APP_SECRET'],
+            0,
+            $iv
+        ));
+
+        return $decryptedString;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
       "php": "~7.0",
-      "simplesamlphp/simplesamlphp": "^1.7"
-      
+      "simplesamlphp/simplesamlphp": "^1.7",
+      "mashape/unirest-php": "^3.0"
     }
 }


### PR DESCRIPTION
This is the first iteration of the ellucian login service. Basically it allows the developer to create an account for the application to use a proxy login to an ellucian api endpoint. The endpoint generates a token that is stored in a session variable (for now may try using a token factory or something for storage instead).

This will allow the application to connect and use ellucian's application endpoints.